### PR TITLE
Allow Blank Attributes

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -213,7 +213,7 @@ Element.prototype.text = function(val) {
 };
 
 Element.prototype.attr = function(attr, val) {
-    if(val){
+    if (!(typeof val === 'undefined' || val === null)) {
         if(!this.attrs){
           this.attrs = {};
         }


### PR DESCRIPTION
XML allows blank strings as attributes. This commit brings the same semantics to the ltx attributes.
