### PR TITLE
fixed for current browserify

### DIFF
--- a/lib/index-browserify.js
+++ b/lib/index-browserify.js
@@ -1,7 +1,8 @@
 /* Cause browserify to bundle SAX parsers: */
 //require('./sax_easysax');
 //require('./sax_saxjs');
-require('./sax_ltx');
+var parse = require('./parse');
+parse.availableSaxParsers.push(parse.bestSaxParser = require('./sax_ltx'));
 
 /* SHIM */
 module.exports = require('./index');


### PR DESCRIPTION
current browserify version caches all requires for each file, which lets `lib/parse.js` don't find `modName="./sax_ltx.js";require(modName)` anymore since it's not in the cache.
