### PR TITLE
partially parsed attrs in sax_ltx

### DIFF
--- a/lib/sax_ltx.js
+++ b/lib/sax_ltx.js
@@ -19,12 +19,12 @@ var SaxLtx = module.exports = function SaxLtx() {
     var state = STATE_TEXT, remainder;
     var tagName, attrs, endTag, selfClosing, attrQuote;
     var recordStart = 0;
+    var attrName;
 
     this.write = function(data) {
 	if (typeof data !== 'string')
 	    data = data.toString();
         var pos = 0
-        var attrName
 
 	/* Anything from previous write()? */
 	if (remainder) {

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -69,7 +69,7 @@ ltx.availableSaxParsers.forEach(function(saxParser) {
 		var parser = new saxParser();
 		var events = [];
 		parser.on('startElement', function(name, attrs) {
-		    events.push({ start: name, attrs:attrs });
+		    events.push({ start: name, attrs: attrs });
 		});
 		parser.on('endElement', function(name) {
 		    events.push({ end: name });


### PR DESCRIPTION
```
  ♢ ltx with SaxLtx 

  SAX parsing
    ✗ XMPP stream 
        » expected '556890365', 
        got      undefined (==) // parse-test.js:149
    ✗ bug: partial attrs 
        » expected 'urn:ietf:params:xml:ns:xmpp-sasl', 
        got      undefined (==) // parse-test.js:149
```

attrName gets undefined
