### PR TITLE
kinda clone attrs obj argument

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -9,8 +9,8 @@
 function Element(name, attrs) {
     this.name = name
     this.parent = null
-    this.attrs = attrs || {}
     this.children = []
+    this.setAttrs(attrs);
 }
 
 /*** Accessors ***/
@@ -81,6 +81,15 @@ Element.prototype.getXmlns = function() {
     return namespaces
 }
 
+Element.prototype.setAttrs = function(attrs) {
+    this.attrs = {}
+    if (attrs) {
+        for (var i in attrs) {
+            if (attrs.hasOwnProperty(i))
+                this.attrs[i] = attrs[i]
+        }
+    }
+};
 
 /**
  * xmlns can be null, returns the matching attribute.
@@ -262,11 +271,7 @@ Element.prototype.remove = function(el, xmlns) {
  * doing. Building XML with ltx is easy!
  */
 Element.prototype.clone = function() {
-    var clone = this._getElement(this.name, {})
-    for (var k in this.attrs) {
-        if (this.attrs.hasOwnProperty(k))
-            clone.attrs[k] = this.attrs[k]
-    }
+    var clone = this._getElement(this.name, this.attrs)
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i]
         clone.cnode(child.clone ? child.clone() : child)

--- a/ltx-browser.js
+++ b/ltx-browser.js
@@ -122,8 +122,8 @@ module.exports = DOMElement
 function Element(name, attrs) {
     this.name = name
     this.parent = null
-    this.attrs = attrs || {}
     this.children = []
+    this.setAttrs(attrs);
 }
 
 /*** Accessors ***/
@@ -194,6 +194,15 @@ Element.prototype.getXmlns = function() {
     return namespaces
 }
 
+Element.prototype.setAttrs = function(attrs) {
+    this.attrs = {}
+    if (attrs) {
+        for (var i in attrs) {
+            if (attrs.hasOwnProperty(i))
+                this.attrs[i] = attrs[i]
+        }
+    }
+};
 
 /**
  * xmlns can be null, returns the matching attribute.
@@ -375,11 +384,7 @@ Element.prototype.remove = function(el, xmlns) {
  * doing. Building XML with ltx is easy!
  */
 Element.prototype.clone = function() {
-    var clone = this._getElement(this.name, {})
-    for (var k in this.attrs) {
-        if (this.attrs.hasOwnProperty(k))
-            clone.attrs[k] = this.attrs[k]
-    }
+    var clone = this._getElement(this.name, this.attrs)
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i]
         clone.cnode(child.clone ? child.clone() : child)

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -5,6 +5,17 @@ var vows = require('vows')
   , ltx = require('./../lib/index')
 
 vows.describe('ltx').addBatch({
+    'new element': {
+        'doesn\'t reference original attrs object': function() {
+            var o = {'foo': 'bar'}
+            var e = new ltx.Element('e', o)
+            assert.notEqual(e.attrs, o)
+            e.attrs.bar = 'foo'
+            assert.equal(o.bar, undefined)
+            o.foobar = 'barfoo'
+            assert.equal(e.attrs.foobar, undefined)
+        }
+    },
     'serialization': {
         'serialize an element': function() {
             var e = new ltx.Element('e')
@@ -154,7 +165,7 @@ vows.describe('ltx').addBatch({
             assert.equal(orig.getChildText('content'), 'foo')
             assert.equal(clone.children[0].name, 'description')
             assert.equal(clone.getChildText('description'), 'foobar')
-        }
+        },
     },
     'children': {
         'getChildren': function() {
@@ -165,7 +176,7 @@ vows.describe('ltx').addBatch({
             .c('c').t('cbar').up()
             .t('bar')
             .root()
-            
+
             var children = el.children
             assert.equal(children.length, 4)
             assert.equal(children[0].name, 'b')


### PR DESCRIPTION
Address #47 

Ideally el.attrs would be an object with no prototype (`Object.create(null)`) so we wouldn't need hasOwnProperty and iterating would be faster but that would break on IE<9.

Also it's not a deep clone but we do not expect the object to be nested anyway.

So it's not perfect but I think it's better that just referencing the passed object. We can improve later. 
