### PR TITLE
+ Expose expat parser reset function.

### DIFF
--- a/lib/sax/sax_expat.js
+++ b/lib/sax/sax_expat.js
@@ -41,3 +41,7 @@ SaxExpat.prototype.end = function() {
         this.emit('end')
     }
 }
+
+SaxExpat.prototype.reset = function() {
+    this.parser.reset()
+}


### PR DESCRIPTION
As in WebSockets we need to reset the parser to tell it that the new code is a new document with its document root by itself, we need this reset to be called.
