### PR TITLE
ltx.match

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var equal = require('./lib/equal')
 var createElement = require('./lib/createElement')
 var tag = require('./lib/tag')
 var is = require('./lib/is')
+var match = require('./lib/match')
 
 exports = module.exports = tag
 
@@ -17,6 +18,8 @@ exports.equal = equal.equal
 exports.nameEqual = equal.name
 exports.attrsEqual = equal.attrs
 exports.childrenEqual = equal.children
+
+exports.match = match
 
 exports.isNode = is.isNode
 exports.isElement = is.isElement

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,0 +1,21 @@
+'use strict'
+
+var nameEqual = require('./equal').name
+
+module.exports = function match (a, b) {
+  if (!nameEqual(a, b)) return false
+  var attrs = a.attrs
+  var keys = Object.keys(attrs)
+  var length = keys.length
+
+  for (var i = 0, l = length; i < l; i++) {
+    var key = keys[i]
+    var value = attrs[key]
+    if (value == null || b.attrs[key] == null) { // === null || undefined
+      if (value !== b.attrs[key]) return false
+    } else if (value.toString() !== b.attrs[key].toString()) {
+      return false
+    }
+  }
+  return true
+}

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+var vows = require('vows')
+var assert = require('assert')
+var ltx = require('../index')
+var Element = ltx.Element
+var match = require('../lib/match')
+
+vows.describe('match').addBatch({
+  'exported correctly': function () {
+    assert.strictEqual(ltx.match, match)
+  },
+  'it returns true if elements name are equal': function () {
+    var a = new Element('foo')
+    var b = new Element('foo')
+    assert.equal(match(a, b), true)
+  },
+  'it returns false if elements name differ': function () {
+    var a = new Element('foo')
+    var b = new Element('bar')
+    assert.equal(match(a, b), false)
+  },
+  'it returns true if element attributes match': function () {
+    var a = new Element('foo', {bar: 'hello'})
+    var b = new Element('foo', {bar: 'hello'})
+    assert.equal(match(a, b), true)
+
+    var c = new Element('foo', {bar: 'hello', 'foo': 'baz'})
+    assert.equal(match(a, c), true)
+  },
+  'it returns false if element attributes do not match': function () {
+    var a = new Element('foo', {bar: 'hello'})
+    var b = new Element('foo')
+    assert.equal(match(a, b), false)
+  }
+}).export(module)


### PR DESCRIPTION
RFC

This would be pretty useful in node-xmpp where we're trying to have more self explanatory code.

``` javascript
// example

client.on('stanza', stanza => {
  if (!ltx.match(stanza, <iq><query xmlns="{NS_DISCO}"/></iq>) return
  ...
})
```

Is it useful in ltx?

Should we have element.match?

what about children? text nodes?
