### PR TITLE
Bugfix unescape entities

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -14,15 +14,10 @@ function escapeXMLReplace (match) {
 
 var unescapeXMLTable = {
   '&amp;': '&',
-  '&#38;': '&',
   '&lt;': '<',
-  '&#60;': '<',
   '&gt;': '>',
-  '&#62;': '>',
   '&quot;': '"',
-  '&#34;': '"',
-  '&apos;': "'",
-  '&#39;': "'"
+  '&apos;': "'"
 }
 
 function unescapeXMLReplace (match) {

--- a/lib/escape.js
+++ b/lib/escape.js
@@ -26,6 +26,13 @@ var unescapeXMLTable = {
 }
 
 function unescapeXMLReplace (match) {
+  if (match[1] === '#') {
+    if (match[2] === 'x') {
+      return String.fromCodePoint(parseInt(match.slice(3), 16))
+    } else {
+      return String.fromCodePoint(parseInt(match.slice(2), 10))
+    }
+  }
   return unescapeXMLTable[match]
 }
 
@@ -34,7 +41,7 @@ exports.escapeXML = function escapeXML (s) {
 }
 
 exports.unescapeXML = function unescapeXML (s) {
-  return s.replace(/&(amp|#38|lt|#60|gt|#62|quot|#34|apos|#39);/g, unescapeXMLReplace)
+  return s.replace(/&(amp|lt|gt|quot|apos|#x[0-9a-fA-F]+|#[0-9]+);/g, unescapeXMLReplace)
 }
 
 exports.escapeXMLText = function escapeXMLText (s) {

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -48,6 +48,21 @@ vows.describe('escape').addBatch({
     },
     'unescapes \'': function () {
       assert.equal(unescapeXML('&apos;'), '\'')
+    },
+    'unescapes numeric entities': function () {
+      assert.equal(unescapeXML('&#64;'), '@')
+    },
+    'unescapes hexadecimal entities': function () {
+      assert.equal(unescapeXML('&#x40;'), '@')
+    },
+    'unescapes multibyte hex entities': function () {
+      assert.equal(unescapeXML('&#x1f40d;'), '\uD83D\uDC0D')
+    },
+    'unescapes multibyte uppercase hex entities': function () {
+      assert.equal(unescapeXML('&#x1F40D;'), '\uD83D\uDC0D')
+    },
+    'unescapes multibyte decimal entities': function () {
+      assert.equal(unescapeXML('&#128013;'), '\uD83D\uDC0D')
     }
   },
   'escapeXMLText': {


### PR DESCRIPTION
Hi!  Thanks for this fast XML parser!

I hit this bug and thought I'd swap out with sax-js but a microbenchmark made it slow down XML parsing by a factor of 3, so I thought my time was better spent fixing the issue I have.

The problem is exposed in the tests.  Essentially, if an XML file contains &#123; or &#x123ABC; it should treat these as [character references](https://www.w3.org/TR/xml/#dt-charref) meaning that it should take it as character 123 or the character parseInt('ABC123', 16) respectively.
I hope I followed the coding standards; yarn test warned me about changing == to === so I did that :-)

Even though the change is simple, I split it into three commits, 40ab541 is the real "work" of the PR.