### PR TITLE
Remove Documentation link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ ltx supports third party parsers when such features are needed.
 
 From [ltx/benchmarks/parsers.js](https://github.com/node-xmpp/ltx/blob/master/benchmarks/parsers.js), higher is better.
 
-## Documentation
-
-http://node-xmpp.org/doc/ltx.html
-
 ## Benchmark
 
 ```


### PR DESCRIPTION
The http://node-xmpp.org site appears to just serve malware at this point.  It'd be great if the documentation were fixed, but for now, just removing the potentially malicious link.