### PR TITLE
Throw on invalid entity

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -38,7 +38,10 @@ function unescapeXMLReplace (match) {
     }
     throw new Error('Illegal XML character 0x' + num.toString(16))
   }
-  return unescapeXMLTable[match] || match
+  if (unescapeXMLTable[match]) {
+    return unescapeXMLTable[match] || match
+  }
+  throw new Error('Illegal XML entity ' + match)
 }
 
 exports.escapeXML = function escapeXML (s) {

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -49,8 +49,8 @@ vows.describe('escape').addBatch({
     'unescapes \'': function () {
       assert.strictEqual(unescapeXML('&apos;'), '\'')
     },
-    'leaves invalid entities alone': function () {
-      assert.strictEqual(unescapeXML('&foobar;'), '&foobar;')
+    'throws on invalid entities': function () {
+      assert.throws(() => unescapeXML('&foobar;'), Error, 'Illegal XML entity &foobar;')
     },
     'unescapes numeric entities': function () {
       assert.strictEqual(unescapeXML('&#64;'), '@')


### PR DESCRIPTION
This throws an error: `Illegal XML entity 'foobar'` if it sees the text `&foobar;`.

This is a breaking change, in that it changes the behaviour to be a standard.  It can surely be described as a bugfix, because some might say that accepting invalid XML is a bug.  The PR builds on #125 mainly because it changes the test introduced by #125, I wil happily rebase it if/when #125 is merged.  The code change itself can be applied regardless of #125.