### PR TITLE
Fix CDATA parsing when content is split between chunks

### DIFF
--- a/lib/parsers/ltx.js
+++ b/lib/parsers/ltx.js
@@ -21,6 +21,7 @@ var SaxLtx = module.exports = function SaxLtx () {
 
   var state = STATE_TEXT
   var remainder
+  var parseRemainder
   var tagName
   var attrs
   var endTag
@@ -50,7 +51,8 @@ var SaxLtx = module.exports = function SaxLtx () {
     /* Anything from previous write()? */
     if (remainder) {
       data = remainder + data
-      pos += remainder.length
+      pos += !parseRemainder ? remainder.length : 0
+      parseRemainder = false
       remainder = null
     }
 
@@ -107,12 +109,17 @@ var SaxLtx = module.exports = function SaxLtx () {
           }
           break
         case STATE_CDATA:
-          if (c === 93 /* ] */ && data.substr(pos + 1, 2) === ']>') {
-            var cData = endRecording()
-            if (cData) {
-              this.emit('text', cData)
+          if (c === 93 /* ] */) {
+            if (data.substr(pos + 1, 2) === ']>') {
+              var cData = endRecording()
+              if (cData) {
+                this.emit('text', cData)
+              }
+              state = STATE_TEXT
+            } else if (data.length < pos + 2) {
+              parseRemainder = true
+              pos = data.length
             }
-            state = STATE_TEXT
           }
           break
         case STATE_TAG_NAME:
@@ -123,6 +130,10 @@ var SaxLtx = module.exports = function SaxLtx () {
             if (data.substr(pos + 1, 7) === '[CDATA[') {
               recordStart = pos + 8
               state = STATE_CDATA
+            } else if (data.length < pos + 8 && '[CDATA['.startsWith(data.substr(pos + 1))) {
+              // We potentially have CDATA, but the chunk is ending; stop here and let the next write() decide
+              parseRemainder = true
+              pos = data.length
             } else {
               recordStart = undefined
               state = STATE_IGNORE_COMMENT

--- a/test/cdata-test.js
+++ b/test/cdata-test.js
@@ -64,6 +64,15 @@ vows.describe('sax_ltx').addBatch({
       assert.strictEqual(el2.getText(), 'Content')
       var el3 = parseChunks(['<root><![CDATA[Content]]', '></root>'])
       assert.strictEqual(el3.getText(), 'Content')
+
+      var str = '<root><![CDATA[Content]]></root>'
+      for (var i = 0; i < str.length; i++) {
+        var chunks = [
+          str.substr(0, i) || '',
+          str.substring(i) || ''
+        ]
+        assert.strictEqual(parseChunks(chunks).toString(), '<root>Content</root>')
+      }
     }
   }
 }).export(module)


### PR DESCRIPTION
The CDATA parsing logic did not handle chunked data parsing correctly, leading to missing/broken data.

This PR fixes it by detecting when a CDATA entry is split between 2 chunks and parsing it fully on the second chunk.