### PR TITLE
fix stringify escaping when text or attribute contains entities

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var escapeXML = require('./escape').escapeXML
+
 function stringify (el, indent, level) {
   if (typeof indent === 'number') indent = ' '.repeat(indent)
   if (!level) level = 1
@@ -7,7 +9,7 @@ function stringify (el, indent, level) {
   s += '<' + el.name
 
   Object.keys(el.attrs).forEach(function (k) {
-    s += ' ' + k + '=' + '"' + el.attrs[k] + '"'
+    s += ' ' + k + '=' + '"' + escapeXML(el.attrs[k]) + '"'
   })
 
   if (el.children.length) {
@@ -15,7 +17,7 @@ function stringify (el, indent, level) {
     el.children.forEach(function (child, i) {
       if (indent) s += '\n' + indent.repeat(level)
       if (typeof child === 'string') {
-        s += child
+        s += escapeXML(child)
       } else {
         s += stringify(child, indent, level + 1)
       }

--- a/test/stringify-test.js
+++ b/test/stringify-test.js
@@ -21,6 +21,30 @@ vows.describe('stringify').addBatch({
     `
     assert.strictEqual(el.toString(), stringify(el))
   },
+  'while having entities in text, return the same result than .toString()': function () {
+    const el = ltx`
+      <foo bar="foo">
+        &gt;text
+        <child foo="bar">
+          &lt;text
+          <self-closing/>
+        </child>
+      </foo>
+    `
+    assert.strictEqual(el.toString(), stringify(el))
+  },
+  'while having entities in attribute, return the same result than .toString()': function () {
+    const el = ltx`
+      <foo bar="&amp;foo">
+        &gt;text
+        <child foo="&amp;bar">
+          &lt;text
+          <self-closing/>
+        </child>
+      </foo>
+    `
+    assert.strictEqual(el.toString(), stringify(el))
+  },
   'indents correctly': function () {
     const el = ltx`<foo><bar hello="world">text<self/></bar></foo>`
 


### PR DESCRIPTION
This PR fixes the `stringify()` not escape entities while the xml attribute or child text contains entities like `>` `<`, etc( #139), please have a look